### PR TITLE
Update sslmate to 0.5.0

### DIFF
--- a/aur/sslmate/PKGBUILD
+++ b/aur/sslmate/PKGBUILD
@@ -1,7 +1,7 @@
 # Maintainer: Yuval Adam <yuv dot adm at gmail dot com> PGP-Key: CC2115C12D99D2F0
 
 pkgname=sslmate
-pkgver=0.4.3
+pkgver=0.5.0
 pkgrel=1
 pkgdesc="Buy SSL certs from the command line"
 arch=('any')
@@ -9,7 +9,7 @@ url="https://sslmate.com/"
 license=(unknown)
 depends=(perl perl-uri perl-term-readkey)
 source=("https://packages.sslmate.com/other/sslmate-${pkgver}.tar.gz") 
-sha1sums=('b24a6038c792a9d21727ad10b5f55a49bc292db7')
+sha1sums=('d1e2fc21f7b089af1aaf0afb25b89130530c5609')
 
 package() {
   cd $srcdir/${pkgname}-${pkgver}


### PR DESCRIPTION
SSLMate recently released 0.5.0. Could you update the PKGBUILD for it?

Thanks!
