### PR TITLE
stage1.aci needs to be installed as well

### DIFF
--- a/aur/rocket/PKGBUILD
+++ b/aur/rocket/PKGBUILD
@@ -14,6 +14,7 @@ sha1sums=('725988dbb3ae0690887bf0cef39a6208613cd5d5')
 package() {
   cd $srcdir/${pkgname}-v${pkgver}
   install -Dm755 rkt ${pkgdir}/usr/bin/rkt
+  install -Dm644 stage1.aci ${pkgdir}/usr/bin/stage1.aci
 }
 
 # vim:set ts=2 sw=2 et:


### PR DESCRIPTION
As long as we are just distributing binaries, the stage1.aci needs to be present in /usr/bin - this PR fixes that.

More long term, it's better to compile it from sources and have the stage1.aci placed somewhere under /usr/share ref https://github.com/coreos/rocket/issues/457