### PR TITLE
Project was officially renamed to rkt upstream

### DIFF
--- a/aur/rkt/PKGBUILD
+++ b/aur/rkt/PKGBUILD
@@ -1,25 +1,27 @@
 # Maintainer: Yuval Adam <yuval at y3xz dot com> PGP-Key: 271386AA2EB7672F
 # Contributor: Kenny Rasschaert <kenny dot rasschaert at gmail dot com> PGP-Key: 1F70454121E41419
 
-pkgname=rocket
+pkgname=rkt
 pkgver=0.5.3
 pkgrel=1
 pkgdesc="App container runtime"
 arch=('x86_64')
-url="https://github.com/coreos/rocket"
+url="https://github.com/coreos/rkt"
 license=(apache)
 makedepends=('cpio' 'go' 'squashfs-tools')
-provides=('rocket')
-source=("https://github.com/coreos/rocket/archive/v${pkgver}.tar.gz")
+provides=('rkt')
+replaces=('rocket')
+conflicts=('rocket')
+source=("https://github.com/coreos/rkt/archive/v${pkgver}.tar.gz")
 sha1sums=('1a1f68091340e94d0ac2f80b8fb7dd6115191b99')
 
 build() {
-  cd "rkt-${pkgver}"
+  cd "${pkgname}-${pkgver}"
   RKT_STAGE1_IMAGE=/usr/share/rkt/stage1.aci ./build
 }
 
 package() {
-  cd "rkt-${pkgver}"
+  cd "${pkgname}-${pkgver}"
   install -Dm755 bin/rkt "$pkgdir/usr/bin/rkt"
   install -Dm644 bin/stage1.aci "$pkgdir/usr/share/rkt/stage1.aci"
 }


### PR DESCRIPTION
Earlier when updating rocket to 0.5 I had noticed they changed the folder inside the tarball from "rocket" to "rkt", not realizing what brought on this change. It turns out the project has officially changed their name to "rkt".

Quote from the [official announcement](https://coreos.com/blog/announcing-rkt-0.5/):

> "Rocket", "rocket", "rkt"?
> This release also sees us standardizing on a single name for all areas of the project - the command-line tool, filesystem names and Unix groups, and the title of the project itself. Instead of "rocket", "Rocket", or "rock't", we now simply use "rkt".