### PR TITLE
Update sslmate to 1.0.0

### DIFF
--- a/aur/sslmate/PKGBUILD
+++ b/aur/sslmate/PKGBUILD
@@ -1,18 +1,19 @@
 # Maintainer: Yuval Adam <yuval at y3xz dot com> PGP-Key: 271386AA2EB7672F
 
 pkgname=sslmate
-pkgver=0.6.2
+pkgver=1.0.0
 pkgrel=1
 pkgdesc="Buy SSL certs from the command line"
 arch=('any')
 url="https://sslmate.com/"
 license=(unknown)
 depends=(perl perl-uri perl-term-readkey)
+optdepends=('python2-boto: Route 53 DNS approval support')
 source=("https://packages.sslmate.com/other/sslmate-${pkgver}.tar.gz") 
-sha1sums=('84e158bc3302c66f0e7bba25c1157d1a9220c86a')
+sha1sums=('1245052444f6ed959fac313430990150444e3b76')
 
 package() {
   cd $srcdir/${pkgname}-${pkgver}
-  make install PREFIX=${pkgdir}/usr
+  make install PREFIX=/usr DESTDIR=${pkgdir}
 }
 # vim:set ts=2 sw=2 et:


### PR DESCRIPTION
I've also added an optional dependency on python2-boto, for an optional feature added in this version of sslmate.  The PKGBUILD documentation for optional dependencies was pretty straightforward, but I'm admittedly not familiar with Arch packaging, so if you could check to make sure I did this correctly, I'd appreciate it.

Thanks!