### PR TITLE
Fix rkt{,-git} PKGBUILDs for new build system in v0.7.0

### DIFF
--- a/aur/rkt-git/PKGBUILD
+++ b/aur/rkt-git/PKGBUILD
@@ -1,15 +1,16 @@
 # Maintainer: Yuval Adam <yuval at y3xz dot com> PGP-Key: 271386AA2EB7672F
 # Contributor: Kenny Rasschaert <kenny dot rasschaert at gmail dot com> PGP-Key: 1F70454121E41419
+# Contributor: Adrián Pérez de Castro <adrian at perezdecastro dor org> PGP-Key: 91C559DBE4C9123B
 # Contributor: Boohbah <boohbah at gmail dot com>
 
 pkgname=rkt-git
-pkgver=0.5.6.r22.g2440b4a
+pkgver=0.7.0.r47.gfd6e630
 pkgrel=1
 pkgdesc="App container runtime"
 arch=('x86_64')
 url="https://github.com/coreos/rkt"
 license=(apache)
-makedepends=('cpio' 'go' 'squashfs-tools')
+makedepends=('cpio' 'go' 'squashfs-tools' 'perl-capture-tiny')
 provides=('rkt')
 replaces=('rocket' 'rkt')
 conflicts=('rocket' 'rkt')
@@ -21,14 +22,23 @@ pkgver() {
   git describe --long | sed -E 's/^v//;s/([^-]*-g)/r\1/;s/-/./g'
 }
 
+prepare () {
+  cd "${pkgname}"
+  ./autogen.sh
+}
+
 build() {
   cd "$pkgname"
-  RKT_STAGE1_IMAGE=/usr/share/rkt/stage1.aci ./build
+  ./configure --prefix=/usr \
+    --with-stage1=coreos \
+    --with-stage1-image-path=/usr/share/rkt/stage1.aci
+  make -s
 }
 
 package() {
-  cd "$pkgname"
+  cd "${pkgname}"/build-rkt-*+git
   install -Dm755 bin/rkt "$pkgdir/usr/bin/rkt"
+  install -Dm755 bin/actool "$pkgdir/usr/bin/actool"
   install -Dm644 bin/stage1.aci "$pkgdir/usr/share/rkt/stage1.aci"
 }
 

--- a/aur/rkt/PKGBUILD
+++ b/aur/rkt/PKGBUILD
@@ -1,28 +1,39 @@
 # Maintainer: Yuval Adam <yuval at y3xz dot com> PGP-Key: 271386AA2EB7672F
 # Contributor: Kenny Rasschaert <kenny dot rasschaert at gmail dot com> PGP-Key: 1F70454121E41419
+# Contributor: Adrián Pérez de Castro <adrian at perezdecastro dor org> PGP-Key: 91C559DBE4C9123B
 
 pkgname=rkt
-pkgver=0.5.6
+pkgver=0.7.0
 pkgrel=1
 pkgdesc="App container runtime"
 arch=('x86_64')
 url="https://github.com/coreos/rkt"
 license=(apache)
-makedepends=('cpio' 'go' 'squashfs-tools')
+makedepends=('cpio' 'go' 'squashfs-tools' 'perl-capture-tiny')
+depends=('glibc')
 provides=('rkt')
 replaces=('rocket')
 conflicts=('rocket')
 source=("https://github.com/coreos/rkt/archive/v${pkgver}.tar.gz")
-sha256sums=('bae39568c9e980245b13309ba89eac1f31ba8e29d7ccf3e0f85b75c34ae57a7d')
+sha256sums=('1e5996c9c26a69f107d9d4f8dd2a3e55ca3a9b8491ecbd9fe2dfe423c7c384ce')
+
+prepare () {
+  cd "${pkgname}-${pkgver}"
+  ./autogen.sh
+}
 
 build() {
   cd "${pkgname}-${pkgver}"
-  RKT_STAGE1_IMAGE=/usr/share/rkt/stage1.aci ./build
+  ./configure --prefix=/usr \
+    --with-stage1=coreos \
+    --with-stage1-image-path=/usr/share/rkt/stage1.aci
+  make -s
 }
 
 package() {
-  cd "${pkgname}-${pkgver}"
+  cd "${pkgname}-${pkgver}/build-${pkgname}-${pkgver}"
   install -Dm755 bin/rkt "$pkgdir/usr/bin/rkt"
+  install -Dm755 bin/actool "$pkgdir/usr/bin/actool"
   install -Dm644 bin/stage1.aci "$pkgdir/usr/share/rkt/stage1.aci"
 }
 


### PR DESCRIPTION
This fixes the build for `rkt` and `rkt-git`; the build system has changed at some point between v0.6 and v0.7.